### PR TITLE
fix: open-browser parameter of typst-preview-mode

### DIFF
--- a/typst-preview.el
+++ b/typst-preview.el
@@ -164,7 +164,7 @@ This is intended for multi-file projects where a file is included using e.g. #in
   (if typst-preview-mode
       (if typst-preview-autostart
 	  (progn
-	    (typst-preview-start)
+	    (typst-preview-start typst-preview-open-browser-automatically)
 	    (message "Typst preview started!"))
 	(message "Typst-preview-mode enabled, run `typst-preview-start' to start preview"))
     (remove-hook 'after-change-functions #'tp--send-buffer-on-type t))
@@ -194,9 +194,6 @@ This is intended for multi-file projects where a file is included using e.g. #in
 
 If `OPEN-BROWSER' set and non-NIL, then it will automatically open a default browser window."
   (interactive)
-
-  (unless (boundp open-browser)
-    (setq open-browser typst-preview-open-browser-automatically))
 
   (unless (executable-find (car (split-string typst-preview-executable)))
     (error "Typst-preview executable not found. Please install tinymist or


### PR DESCRIPTION
An elisp function cannot discern if an optional parameter has been provided as NIL or not specified at the call site.

Fixes the issue that `typst-preview-open-browser-automatically` configuration option has no effect by passing it explicitly at the relevant call site to `typst-preview-start`.