### PR TITLE
Impersonate VSCode

### DIFF
--- a/typst-preview.el
+++ b/typst-preview.el
@@ -261,6 +261,7 @@ typst-preview, or modify `typst-preview-executable'"))
       ;; connect to typst-preview socket
       (setq tp--control-socket
 	    (websocket-open (concat "ws://" tp--control-host)
+			    :custom-header-alist '(("origin" . "vscode-webview://emacs"))
 			    :on-message (lambda (_websocket frame) (tp--parse-message _websocket frame))
 			    :on-close (lambda (_websocket) (message "Typst-preview-mode websocket closed."))))
       


### PR DESCRIPTION
Since https://github.com/Myriad-Dreamin/tinymist/pull/1157 was merged, tinymist rejects connections on the control plane websocket without a valid `Origin` header as set by VSCode.
This causes the websocket connection to instantly be closed, thus breaking typst-preview.el.
With this PR, we "impersonate" VSCode by sending an acceptable `Origin`.