### PR TITLE
Change mode line display, unify toggle mode and call start/stop

### DIFF
--- a/typst-preview.el
+++ b/typst-preview.el
@@ -158,7 +158,7 @@ This is intended for multi-file projects where a file is included using e.g. #in
 (define-minor-mode typst-preview-mode
   "Toggle typst-preview minor mode."
   :init nil
-  :lighter " typst-preview "
+  :lighter " typst-preview"
   :global nil
 
   (if typst-preview-mode

--- a/typst-preview.el
+++ b/typst-preview.el
@@ -158,7 +158,7 @@ This is intended for multi-file projects where a file is included using e.g. #in
 (define-minor-mode typst-preview-mode
   "Toggle typst-preview minor mode."
   :init nil
-  :lighter "typst-preview"
+  :lighter " typst-preview "
   :global nil
 
   (if typst-preview-mode
@@ -167,7 +167,7 @@ This is intended for multi-file projects where a file is included using e.g. #in
 	    (typst-preview-start typst-preview-open-browser-automatically)
 	    (message "Typst preview started!"))
 	(message "Typst-preview-mode enabled, run `typst-preview-start' to start preview"))
-    (remove-hook 'after-change-functions #'tp--send-buffer-on-type t))
+    (typst-preview-stop))
   :key-map typst-preview-mode-map )
 
 
@@ -303,19 +303,19 @@ typst-preview, or modify `typst-preview-executable'"))
 (defun typst-preview-stop ()
   "Stop typst-preview buffer by killing websocket connection."
   (interactive)
-  (when (bound-and-true-p typst-preview-mode)
-    (if (not (typst-preview-connected-p))
-	(message "No active typst preview in this buffer.")
-      (let ((global-master (car (member tp--local-master tp--active-masters))))
-	(if (not (string-equal tp--master-file tp--file-path))
-	    (setf (tp--master-children global-master)
-		  (delete tp--file-path (tp--master-children global-master)))
-	  (delete-process tp--process)
-	  (delete (list tp--file-path) tp--active-buffers)
-	  (setf tp--active-masters (delete tp--local-master tp--active-masters))
-	  (if (eq '() tp--active-masters)
-	      (kill-buffer tp--ws-buffer)))
-	(kill-local-variable 'tp--local-master)))))
+  (if (not (typst-preview-connected-p))
+      (message "No active typst preview in this buffer.")
+    (let ((global-master (car (member tp--local-master tp--active-masters))))
+      (if (not (string-equal tp--master-file tp--file-path))
+	  (setf (tp--master-children global-master)
+		(delete tp--file-path (tp--master-children global-master)))
+	(delete-process tp--process)
+	(delete (list tp--file-path) tp--active-buffers)
+	(setf tp--active-masters (delete tp--local-master tp--active-masters))
+	(if (eq '() tp--active-masters)
+	    (kill-buffer tp--ws-buffer)))
+      (kill-local-variable 'tp--local-master)
+      (remove-hook 'after-change-functions #'tp--send-buffer-on-type t))))
 
 ;;;###autoload
 (defun typst-preview-restart ()


### PR DESCRIPTION
I made some minor changes to the package:

1. The indicator for the minor mode is changed from `"typst-preview"` to `" typst-preview "`. This is intended to prevent the mode line indicator concatenating with indicators for other modes.

2. I unify the behavior of toggling the minor mode and manually call the start/stop function. Now the minor mode toggling simply delegate works to start/stop procedures. In the previous implementation, disabling the minor mode and calling `typst-preview-stop` were doing totally different things. Now, users can choose to enable/disable the minor mode, or explicitly call `typst-preview-start/stop`. They are equivalent now.

3. `typst-preview-stop` no longer requires to be in `typst-preview-mode` to do its work, since it is possible to preview without enabling the mode. (By calling `typst-preview-start` explicitly.)