### PR TITLE
Make the adding to kill-buffer-hook buffer local

### DIFF
--- a/typst-preview.el
+++ b/typst-preview.el
@@ -286,7 +286,7 @@ typst-preview, or modify `typst-preview-executable'"))
       (message "Typst-preview started, navigate to %s in your browser or run `typst-preview-open-browser'." tp--static-host))
     
     (push `(,tp--file-path) tp--active-buffers)
-    (add-hook 'kill-buffer-hook #'typst-preview-stop)
+    (add-hook 'kill-buffer-hook #'typst-preview-stop nil t)
     ))
 
 ;;;###autoload


### PR DESCRIPTION
I just find that `typst-preview-stop` was added to `kill-buffer-hook` globally, which seems unnecessary.